### PR TITLE
Refine W3 design: typing, parser, retry, ADRs

### DIFF
--- a/docs/migration-investigation/01-decisions.md
+++ b/docs/migration-investigation/01-decisions.md
@@ -105,17 +105,251 @@ promotion from `devel/`:
   refactor/modular branch tip may show the older versions
   depending on what was last pushed)
 
-**Carries to W3?** Yes, with module renaming. As an external
-command, the namespace becomes `Homebrew::Cmd::Babble` for the
-entry class and `Babble::*` for substantive modules. The split
-between `BrewUpdate`, `BrewUpgrade`, `MasUpgrade`, `MacOSUpdate`,
+**Carries to W3?** Yes, with namespace flattening. As an
+external command, the entry point is the class
+`Homebrew::Cmd::Babble < AbstractCommand`; substantive
+components live in `Babble::*`. The split between
+`BrewUpdate`, `BrewUpgrade`, `MasUpgrade`, `MacOSUpdate`,
 `AppManager`, `BundleLauncher`, `Waiter`, plus the new
-`Config::{Loader, Validator, Reorganizer}` triple and the new
-`TerminalDetector`, follows refactor/modular's boundaries with
-the configuration concerns extracted to their own namespace.
-The `MacUtils::*` and `MacOSInterface::*` namespaces collapse
-into `Babble::*` — there's no good reason to maintain
-sub-namespaces in a single-purpose external command.
+`Config::{Loader, Validator, Merger, Reorganizer}` quartet
+and the new `TerminalDetector`, follows refactor/modular's
+boundaries with the configuration concerns extracted to
+their own namespace. The `MacUtils::*` and `MacOSInterface::*`
+namespaces collapse into `Babble::*` — there's no good reason
+to maintain sub-namespaces in a single-purpose external
+command.
+
+**Whether each is shaped as a class or a module** is a
+separate question — see [Class-vs-module decomposition
+pattern](#class-vs-module-decomposition-pattern) below.
+
+## Class-vs-module decomposition pattern
+
+The "Module decomposition" section above lists *which* logical
+units exist; this section addresses *how* each is shaped — as
+a class or as a module-with-module-functions.
+
+### Pattern guidance
+
+The two Ruby idioms differ in whether they encapsulate state:
+
+**Classes for state-bearing components.** Use a class when the
+component has fields that multiple methods read and modify
+during a single run: configuration loaded from disk, lists of
+running apps captured at one point and consumed later, retry
+counters, cached lookups. State lives in `@instance_variables`;
+dependencies arrive via the constructor; multiple instances
+are possible (useful for testing).
+
+**Modules for pure utilities.** Use a module-with-`module_function`
+or `class << self` block when each method takes its inputs as
+arguments and returns its outputs without reading or mutating
+shared state. Shell-out helpers, retry-with-backoff,
+prefix-the-message helpers, env-file loaders.
+
+### Reasoning
+
+This is what Homebrew's own code does. Inspecting the active
+codebase:
+
+- `Homebrew::Cmd::Upgrade < AbstractCommand` — class (entry
+  point with parsed args + `run` method)
+- `Homebrew::Cleanup` — class with `attr_reader`, `initialize`
+  (state-bearing)
+- `Homebrew::Reinstall` — module with `module_function`
+- `Cask::Caskroom` — module with module methods
+- `Formula.installed` — class method on the Formula class
+
+Pattern: classes for stateful domain objects, modules for
+pure utilities, single-instance entry-point classes extending
+`AbstractCommand`.
+
+The pre-refactor archive at `stash/pre-refactor/lib/` got
+this right for the components there: `class AppManager`
+initialized from `@config_files`, `class ConfigManager`
+similarly. Multiple methods sharing state across a run —
+class is correct.
+
+Refactor/modular's all-modules approach is uneven on this
+question. Some modules are pure utilities (`MasUpgrade`'s
+parsing, `DarkMode.enabled?`) — module is correct. Others
+have state that they hide in `class << self` blocks plus
+`@class_variables` (`BrewUpgrade` carries running-apps
+snapshots, the upgrade list, retry counters at module level).
+That hybrid is the worst of both worlds: it feels like a
+class but loses encapsulation, makes testing harder, and
+prevents multiple parallel instances.
+
+W3 chooses explicitly per component.
+
+### W3 component classification
+
+**Classes (state-bearing):**
+
+- `Homebrew::Cmd::Babble < AbstractCommand` — entry point;
+  parsed CLI args + `run` method per Homebrew's external
+  command idiom
+- `Babble::Config::{Loader, Validator, Merger, Reorganizer}` —
+  each holds its slice of state (loaded files, validation
+  results, merged config, reorganized output)
+- `Babble::Config` — top-level façade holding the merged
+  validated config; exposes `#valid?`, `#errors`, `#warnings`,
+  `#conflicts`, `#homebrew_entries`, `#mas_entries`
+- `Babble::AppManager` — holds `@config` reference + cached
+  running-app snapshots; methods orchestrate quit/reopen
+  across the upgrade lifecycle
+- `Babble::BrewUpdate`, `BrewUpgrade`, `MasUpgrade`,
+  `MacOSUpdate` — each phase is a class taking
+  `(app_manager:, config:)` in the constructor and exposing
+  `#run`. Phase-local state (which casks are outdated, which
+  apps need reopening, retry counters) lives in instance vars.
+
+**Modules (pure utilities):**
+
+- `Babble::Sh` — shell-out wrappers (or use Homebrew's
+  `SystemCommand::Mixin` directly)
+- `Babble::Retry` — retry-with-backoff helper
+  (`Babble::Retry.with_retry { ... }`)
+- `Babble::Env` — env-file loader; mutates `ENV` but doesn't
+  carry state across calls
+- `Babble::TerminalDetector` — one-shot detection
+  (`Babble::TerminalDetector.host_terminal_casks`)
+- `Babble::DarkMode` — `Babble::DarkMode.enabled?`
+- `Babble::Formatter` — prefix-the-message helpers, if any
+  beyond what Homebrew's `oh1`/`ohai`/`opoo`/`ofail` provide
+
+### Entry point shape
+
+```ruby
+# cmd/babble.rb (Homebrew external command)
+require "abstract_command"
+
+module Homebrew
+  module Cmd
+    class Babble < AbstractCommand
+      cmd_args do
+        description <<~EOS
+          An upgrade routine for Homebrew, Mac App Store, and macOS.
+        EOS
+
+        switch "--no-update",
+               description: "Skip the brew update phase."
+        switch "--always-descriptions",
+               description: "Force descriptions for new formulae and casks."
+        # ...
+      end
+
+      sig { override.void }
+      def run
+        Babble::Env.load_default_locations
+
+        config = Babble::Config.load
+        config.report_warnings_and_conflicts!
+
+        app_manager = Babble::AppManager.new(config: config)
+
+        Babble::BrewUpdate.new(app_manager: app_manager, args: args).run
+        Babble::BrewUpgrade.new(app_manager: app_manager, config: config, args: args).run
+        Babble::MasUpgrade.new(app_manager: app_manager, args: args).run
+        Babble::MacOSUpdate.new(args: args).run
+      end
+    end
+  end
+end
+```
+
+### Phase class shape
+
+```ruby
+# cmd/babble/brew_upgrade.rb
+module Babble
+  class BrewUpgrade
+    sig {
+      params(app_manager: AppManager, config: Config, args: T.untyped).void
+    }
+    def initialize(app_manager:, config:, args:)
+      @app_manager = app_manager
+      @config = config
+      @args = args
+      @outdated_casks = T.let([], T::Array[String])
+      @running_at_start = T.let(nil, T.nilable(T::Array[String]))
+    end
+
+    sig { void }
+    def run
+      list_outdated
+      capture_running_apps
+      quit_apps_for_outdated_casks
+      run_upgrade
+      reopen_quit_apps
+    end
+
+    private
+
+    sig { void }
+    def list_outdated
+      # ... populates @outdated_casks
+    end
+
+    sig { void }
+    def capture_running_apps
+      @running_at_start = @app_manager.running_bundle_ids
+    end
+
+    # ... etc
+  end
+end
+```
+
+### Module shape (pure utility)
+
+```ruby
+# cmd/babble/retry.rb
+module Babble
+  module Retry
+    class << self
+      sig do
+        type_parameters(:T)
+          .params(
+            max:     Integer,
+            on_fail: T.proc.params(attempt: Integer).void,
+            block:   T.proc.returns(T.type_parameter(:T)),
+          )
+          .returns(T.nilable(T.type_parameter(:T)))
+      end
+      def with_retry(max: 10, on_fail: ->(_n) {}, &block)
+        attempts = 0
+        loop do
+          result = yield
+          return result if result
+          attempts += 1
+          break if attempts >= max
+          on_fail.call(attempts)
+        end
+        nil
+      end
+    end
+  end
+end
+```
+
+The body of the method takes its inputs as arguments and
+returns its outputs. No state across calls. Module is
+correct.
+
+### Why not `module_function` everywhere?
+
+`module_function` makes methods callable as both module
+methods and instance methods (via `include`). For a single-
+purpose external command like babble, no caller is going to
+`include Babble::Retry` to get `with_retry` as an instance
+method. The `class << self` form is more explicit and equally
+ergonomic.
+
+`module_function` is appropriate when the pattern of "include
+me for a mixin" is genuinely useful (e.g., `Homebrew::Reinstall`
+gets included by `Cmd::Reinstall`). Babble doesn't have that
+shape.
 
 ## Module-level imports and dependencies
 
@@ -378,22 +612,134 @@ BABBLE_CONFIRM_DEFAULT=gui
 BABBLE_QUIET=1
 ```
 
-Lookup order:
+Lookup order, two tiers (user and system) with user winning
+by default:
 
-1. Process environment (set by user shell, command-line
-   prefix, or parent process) — always wins
-2. `${XDG_CONFIG_HOME:-$HOME/.config}/babble/babble.env`
-3. `/etc/babble/babble.env`
+1. **Process environment** (set by user shell, CLI prefix, or
+   parent process) — always wins; no file load can override
+2. **User**:
+   `${XDG_CONFIG_HOME:-$HOME/.config}/babble/babble.env`
+3. **System**: `/etc/babble/babble.env`
 
-No upward directory walk for `babble.env` — these are user
-preferences, not per-project settings. The settings travel
-with the user, not with the directory.
+**Default precedence**: process env > user > system. Loading
+order achieves this via `ENV[key] ||= value` (set only if not
+already set): user loads first, system fills in remaining gaps,
+process env was already in place before either file load.
 
-**Format**: shell-source-compatible `KEY=VALUE` pairs, one
-per line. Comments start with `#`. No quoting required for
-simple values; double-quotes for values with spaces. Babble
-reads the file and sets `ENV[key] = value` for each pair
-before phase orchestration begins; CLI flags override.
+**Sysadmin override**: setting
+`BABBLE_SYSTEM_ENV_TAKES_PRIORITY=1` in the process environment
+inverts the file precedence: system > user. Useful for
+corporate-managed macOS fleets where IT enforces /etc-defined
+defaults that user-set values can't override. Independent of
+Homebrew's `HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY`; the two
+variables are deliberately not coupled (babble and Homebrew
+are separate entities; sysadmins who want both behaviors
+should set both flags explicitly).
+
+The `BABBLE_SYSTEM_ENV_TAKES_PRIORITY` flag itself must be
+set in the process environment to take effect — setting it in
+`babble.env` would create a chicken-and-egg situation since
+the flag controls how `babble.env` is loaded. Document this
+constraint in the user-facing docs.
+
+**Why no prefix tier?** Homebrew's `brew.env` has a third
+tier at `${HOMEBREW_PREFIX}/etc/homebrew/brew.env` because
+Homebrew itself lives at HOMEBREW_PREFIX; per-prefix Homebrew
+config is meaningful when a machine has multiple Homebrew
+installations (Apple Silicon `/opt/homebrew` plus Rosetta
+`/usr/local`). Babble is an external command tap inside
+Homebrew — the tap directory is at
+`${HOMEBREW_PREFIX}/Library/Taps/toobuntu/homebrew-babble/`,
+not `${HOMEBREW_PREFIX}/etc/babble/`. Babble's behavior
+shouldn't differ per Homebrew prefix; user preferences travel
+with the user, not with the install location. The prefix tier
+doesn't carry the same conceptual weight for babble that it
+does for Homebrew, so it's omitted.
+
+No upward directory walk for `babble.env` either — these are
+user/host preferences, not per-project settings.
+
+**Format**: line-based `KEY=VALUE` pairs. The parser is pure
+Ruby (`Babble::Env.load_file`) — no shell sourcing.
+
+Semantics, mirroring Homebrew's `bin/brew`
+`export_homebrew_env_file`:
+
+- One pair per line, matched by the anchored regex
+  `\A([A-Z][A-Z0-9_]*)=(.*)\z`
+- Lines that don't match (comments, blank lines, malformed)
+  are silently skipped
+- Filter to `BABBLE_*` prefix only — other variables are
+  ignored
+- Value is everything after the first `=`, taken **literally**:
+  no shell expansion (`$VAR` stays as `$VAR`), no command
+  substitution (`$(...)` stays as `$(...)`), no quote
+  stripping (`"value"` stays as `"value"` with the quotes)
+- Process environment wins: the parser uses
+  `ENV[key] ||= value`, so an already-set value is preserved.
+  CLI invocations can prefix the variable
+  (`BABBLE_QUIET=1 brew babble`) and that takes priority over
+  the file.
+
+The pure-Ruby parser is mandated by the external command
+shape: Homebrew sources its own `brew.env` in `bin/brew`
+(bash) before the external command's Ruby runs. Babble can't
+insert a pre-Ruby bash step; the parser must run inside Ruby.
+
+```ruby
+module Babble
+  module Env
+    KEY_PATTERN = /\A([A-Z][A-Z0-9_]*)=(.*)\z/
+
+    class << self
+      sig { params(path: T.any(String, Pathname)).void }
+      def load_file(path)
+        return unless File.readable?(path)
+        File.foreach(path) do |line|
+          next unless (m = KEY_PATTERN.match(line.chomp))
+          key, value = m[1], m[2]
+          next unless key.start_with?("BABBLE_")
+          ENV[key] ||= value
+        end
+      end
+
+      sig { void }
+      def load_default_locations
+        xdg_home = ENV["XDG_CONFIG_HOME"] || File.join(ENV.fetch("HOME"), ".config")
+        user_path   = File.join(xdg_home, "babble", "babble.env")
+        system_path = "/etc/babble/babble.env"
+
+        # Each call uses ENV[key] ||= value (set only if not
+        # already set), so the first load to provide a value
+        # wins. The process env (set before babble runs) is
+        # already in ENV and pre-empts every file load.
+        if system_takes_priority?
+          # Sysadmin override: load system first so its values
+          # stick, then user fills in remaining gaps.
+          load_file(system_path)
+          load_file(user_path)
+        else
+          # Default: load user first so user values stick,
+          # then system fills in remaining gaps.
+          load_file(user_path)
+          load_file(system_path)
+        end
+      end
+
+      private
+
+      sig { returns(T::Boolean) }
+      def system_takes_priority?
+        value = ENV["BABBLE_SYSTEM_ENV_TAKES_PRIORITY"]
+        !value.nil? && !value.empty?
+      end
+    end
+  end
+end
+```
+
+Called from `Homebrew::Cmd::Babble#run` before any other
+phase orchestration starts.
 
 **Why not a `settings:` section in `babble.apps.yml`?**
 
@@ -680,9 +1026,20 @@ fail Gatekeeper on Apple Silicon (no Apple Developer cert →
 no codesign → can't distribute). It pivoted to auto-compiling
 on first run via `xcrun swiftc`.
 
-**Carries to W3?** Auto-compile pattern wins. See
+**Carries to W3?** Auto-compile pattern wins, with
+source-hash verification and user-visible transparency on
+first compile. See
 [`adrs/0001-swift-quit-alert-build-strategy.md`](adrs/0001-swift-quit-alert-build-strategy.md)
-for the full ADR. Refactor/modular's pre-compile approach is
+for the full ADR, including the Safety and transparency
+design section that covers: SHA256 sidecar committed
+alongside the source (`quit_alert.swift.sha256`), CI
+enforcement of the sidecar via
+`shasum -a 256 -c`, runtime verification in
+`Babble::QuitAlertCompiler` with hard-fail on hash
+mismatch, `ohai` messages on first compile printing source
+path / target path / command / verified hash, and cache
+key derivation that auto-invalidates when the source
+changes. Refactor/modular's pre-compile approach is
 documented as superseded.
 
 ## yq-based config sorting and dedup detection
@@ -810,9 +1167,31 @@ reserves the right to refactor.
 
 The ksh original wrapped `brew upgrade` in a `repeat_command`
 loop. Up to 10 attempts; between attempts, clear
-`~/Library/Caches/Homebrew/bootsnap`. Added in response to
+`~/Library/Caches/Homebrew/bootsnap`. Added in commit 569b4e0
+in response to
 [Homebrew/brew discussion #5226](https://github.com/orgs/Homebrew/discussions/5226)
-about transient bootsnap-cache corruption.
+about transient bootsnap-cache corruption (the
+`cannot load such file -- json/pure (LoadError)` failure mode).
+
+Upstream may have addressed the original cause:
+- [Homebrew/brew#16977](https://github.com/Homebrew/brew/pull/16977)
+  (31 Mar 2024): "cleanup: fix various cases where cache wasn't
+  being removed properly"
+- [Homebrew/brew#18240](https://github.com/Homebrew/brew/pull/18240)
+  (4 Sep 2024): "Invalidate Bootsnap cache on Gemfile.lock
+  changes"
+- [Homebrew/brew#18246](https://github.com/Homebrew/brew/pull/18246)
+  (4 Sep 2024): "startup/bootsnap: base key on in install state
+  rather than projection"
+
+Whether bootsnap-specific corruption still surfaces in current
+Homebrew is open. The retry mechanism is **kept regardless**:
+it's general defense against any transient `brew upgrade`
+failure (network blips, intermittent rate limits, partial
+downloads), not just bootsnap. The bootsnap-cleanup hook is
+harmless if the cache isn't corrupt — clearing a healthy cache
+costs a few seconds of cache rebuild on the next brew launch,
+no correctness impact.
 
 Refactor/modular's `brew_upgrade.rb` did not port this loop —
 the comment in `run_upgrade_process` notes it as a regression
@@ -947,19 +1326,137 @@ Refactor/modular's modules carry `# typed: strict` and
 out (Sorbet not actively enforced in the year+ work, but the
 shape is ready).
 
-**Carries to W3?** Yes, with active enforcement. As an
-external command, babble inherits Homebrew's Sorbet
-configuration. `# typed: strict` files in the babble code
-get checked in CI via `brew typecheck` (works because the
-file is linked into Homebrew's `cmd/` for CI). Sigs become
-real:
+**Carries to W3?** Yes, with active enforcement.
+
+**Discipline:**
+
+- **Every file is `# typed: strict`** unless there's a
+  documented reason otherwise (rare; only for files that
+  must accept genuinely dynamic input from a non-typed
+  boundary).
+- **Every method has a `sig`**, including private helpers.
+  At `typed: strict`, Sorbet enforces this.
+- **`void` only when justified**: methods that genuinely
+  return nothing meaningful. `initialize` (Ruby convention),
+  `run` entry points on phase classes, and pure side-effect
+  methods that mutate state. Methods with a meaningful return
+  value get the proper return type, never `void`.
+- **`T.untyped` only where unavoidable**: e.g., the `args`
+  object from Homebrew's `cmd_args do ... end` builder is
+  intrinsically dynamic. Everywhere else, prefer specific
+  types: `T::Array[String]`, `T::Hash[String, Integer]`,
+  `T.nilable(String)`, `T::Boolean`, etc.
+- **Type parameters for generic helpers**: `Babble::Retry.with_retry`
+  uses `type_parameters(:T)` so the block's return type
+  flows through.
+- **CI enforcement**: `brew typecheck` (which runs
+  `srb tc`) is a required CI status check. Failures block
+  merge.
+- **Local enforcement**: maintainer runs `brew style` plus
+  `brew typecheck` before each commit. The pre-commit hook
+  (synced from repo-foundation) runs the same.
+
+Example of strict typing in practice:
 
 ```ruby
-sig { params(bundle_id: String, timeout: Integer).returns(T::Boolean) }
-def self.launch(bundle_id, timeout: 10)
-  ...
+# typed: strict
+# frozen_string_literal: true
+
+require "abstract_command"
+require "sorbet-runtime"
+
+module Babble
+  class BrewUpgrade
+    extend T::Sig
+
+    sig { params(app_manager: AppManager, config: Config, args: T.untyped).void }
+    def initialize(app_manager:, config:, args:)
+      @app_manager = app_manager
+      @config = config
+      @args = args
+      @outdated_casks = T.let([], T::Array[String])
+      @running_at_start = T.let(nil, T.nilable(T::Array[String]))
+    end
+
+    sig { void }
+    def run
+      list_outdated
+      capture_running_apps
+      quit_apps_for_outdated_casks
+      run_upgrade
+      reopen_quit_apps
+    end
+
+    sig { returns(T::Array[String]) }
+    def outdated_casks = T.must(@outdated_casks)
+
+    private
+
+    sig { void }
+    def list_outdated
+      output = Utils.safe_popen_read(HOMEBREW_BREW_FILE, "outdated", "--cask", "--json=v2")
+      data = T.let(JSON.parse(output), T::Hash[String, T.untyped])
+      @outdated_casks = T.cast(
+        data.fetch("casks", []).map { |c| T.cast(c.fetch("name"), String) },
+        T::Array[String],
+      )
+    end
+
+    sig { void }
+    def capture_running_apps
+      @running_at_start = @app_manager.running_bundle_ids
+    end
+
+    sig { params(bundle_id: String).returns(T::Boolean) }
+    def app_was_running?(bundle_id)
+      T.must(@running_at_start).include?(bundle_id)
+    end
+  end
 end
 ```
+
+The pseudocode in the
+[Class-vs-module decomposition pattern](#class-vs-module-decomposition-pattern)
+section above shows mostly `void` methods because that's what
+the entry-point + run + state-mutation pattern produces.
+Helper methods, query methods, and computation methods get
+proper return types as shown here.
+
+## Testing discipline
+
+RSpec, with coverage for every component.
+
+**Discipline:**
+
+- **Per-component spec files** mirror the source layout:
+  `cmd/babble/brew_upgrade.rb` → `spec/babble/brew_upgrade_spec.rb`
+- **Public API gets coverage first**: every public method on
+  every class/module has at least one spec example
+- **Edge cases get explicit specs**: empty inputs, nil
+  returns, Unicode bundle IDs, casks with no description,
+  fonts (which intentionally have `desc nil`), etc.
+- **External boundaries are mocked**:
+  - `safe_system HOMEBREW_BREW_FILE, ...` mocked to return
+    canned output
+  - JXA quit calls mocked
+  - File system reads against fixture YAML files in
+    `spec/fixtures/`
+  - Process detection (`ps`, `lsappinfo`) mocked
+- **Integration boundary stays small**: a few spec examples
+  exercise the full phase orchestration end-to-end with
+  mocked boundaries; most specs are unit-level
+- **CI enforcement**: `brew tests` runs the spec suite as a
+  required check
+
+The validation tests already in refactor/modular's
+`BrewUpgrade.test_valid_*` methods (not real specs; just
+method-level sanity checks the maintainer ran manually) become
+proper spec examples in W3. They're a starting point, not the
+final coverage.
+
+Reference: Homebrew's own spec structure at
+`Library/Homebrew/test/` is the model. Each `cmd/foo.rb` has
+a corresponding `test/cmd/foo_spec.rb`. Use the same layout.
 
 ## REUSE/SPDX compliance
 

--- a/docs/migration-investigation/01-decisions.md
+++ b/docs/migration-investigation/01-decisions.md
@@ -627,14 +627,21 @@ already set): user loads first, system fills in remaining gaps,
 process env was already in place before either file load.
 
 **Sysadmin override**: setting
-`BABBLE_SYSTEM_ENV_TAKES_PRIORITY=1` in the process environment
-inverts the file precedence: system > user. Useful for
-corporate-managed macOS fleets where IT enforces /etc-defined
-defaults that user-set values can't override. Independent of
-Homebrew's `HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY`; the two
-variables are deliberately not coupled (babble and Homebrew
-are separate entities; sysadmins who want both behaviors
-should set both flags explicitly).
+`BABBLE_SYSTEM_ENV_TAKES_PRIORITY` to any non-empty value in
+the process environment inverts the file precedence: system
+> user. `1` is the idiomatic example value, but any
+non-empty value enables it — this mirrors Homebrew's
+upstream env-var convention (per `man brew`: "environment
+variables must have a value set to be detected… run
+`export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
+`export HOMEBREW_NO_INSECURE_REDIRECT`"; the `=1` is
+illustrative, not a contract). Useful for corporate-managed
+macOS fleets where IT enforces /etc-defined defaults that
+user-set values can't override. Independent of Homebrew's
+`HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY`; the two variables are
+deliberately not coupled (babble and Homebrew are separate
+entities; sysadmins who want both behaviors should set both
+flags explicitly).
 
 The `BABBLE_SYSTEM_ENV_TAKES_PRIORITY` flag itself must be
 set in the process environment to take effect — setting it in
@@ -728,6 +735,10 @@ module Babble
 
       private
 
+      # Mirrors Homebrew's upstream env-var convention: any
+      # non-empty value enables the flag. `1` is the idiomatic
+      # example, not the only accepted value. Per `man brew`,
+      # the variable need only be "set to be detected".
       sig { returns(T::Boolean) }
       def system_takes_priority?
         value = ENV["BABBLE_SYSTEM_ENV_TAKES_PRIORITY"]

--- a/docs/migration-investigation/adrs/0001-swift-quit-alert-build-strategy.md
+++ b/docs/migration-investigation/adrs/0001-swift-quit-alert-build-strategy.md
@@ -208,7 +208,7 @@ A sibling file `swift/src/quit_alert.swift.sha256` is
 committed alongside the source. Standard SHA256SUMS format
 (`<sha256>  <path>`):
 
-```
+```text
 <64-hex-chars>  swift/src/quit_alert.swift
 ```
 
@@ -220,10 +220,22 @@ shasum -a 256 -c swift/src/quit_alert.swift.sha256
 ```
 
 No Ruby required for the user to confirm the file matches
-what the maintainer committed. The .sha256 file is signed
-by the maintainer's GPG signature on the commit (per the
-org-wide signed-commits convention), so tampering with the
-.sha256 file requires breaking the signature too.
+what's committed in the tap. The recorded hash inherits the
+trust model of the tap content itself: GitHub's TLS-protected
+delivery via `brew update`, plus (forthcoming) cryptographic
+commit signing across the toobuntu org. The planned signing
+convention is SSH-based (GPG and x.509 also acceptable as
+alternative key types) and is distinct from the DCO-style
+`git commit --signoff` currently in use — `--signoff`
+records intent metadata but does not cryptographically
+authenticate the committer. Cryptographic commit signing
+is not yet enabled across toobuntu repos but is planned;
+until then, this hash sidecar provides integrity-against-
+corruption (catches accidental damage and surfaces
+filesystem-level tampering at runtime via
+`Babble::QuitAlertCompiler`'s verification step) but no
+authentication beyond GitHub's transport and the maintainer's
+account credentials.
 
 ### Maintenance flow
 
@@ -245,6 +257,7 @@ layers of defense:
    ```bash
    #!/usr/bin/env bash
    # SPDX-FileCopyrightText: Copyright 2026 Todd Schulman
+   #
    # SPDX-License-Identifier: GPL-3.0-or-later
    #
    # Pre-commit drop-in: regenerate quit_alert.swift's SHA256
@@ -254,7 +267,13 @@ layers of defense:
    set -euo pipefail
 
    main() {
-     cd "$(git rev-parse --show-toplevel)"
+     repo_root="$(git rev-parse --show-toplevel)" || {
+       printf '%s\n' "error: not inside a Git work tree" >&2
+       exit 1
+     }
+
+     cd "$repo_root" || exit 1
+
      update_quit_alert_sha256
    }
 
@@ -274,7 +293,7 @@ layers of defense:
      # staged commits produce a sidecar matching what's actually
      # going into the commit.
      local new_sha
-     new_sha=$(git show ":${source_file}" | shasum --algorithm 256 | awk '{print $1}')
+     new_sha=$(git show ":${source_file}" | /usr/bin/shasum --algorithm 256 | /usr/bin/awk '{print $1}')
      printf '%s  %s\n' "${new_sha}" "${source_file}" > "${sha_file}"
 
      # annotate.sh categorizes .sha256 files into the hash-files
@@ -321,9 +340,17 @@ layers of defense:
    ```sh
    #!/usr/bin/env bash
    set -euo pipefail
+
+   repo_root="$(git rev-parse --show-toplevel)" || {
+     printf '%s\n' "error: not inside a Git work tree" >&2
+     exit 1
+   }
+
+   cd "$repo_root" || exit 1
+
    source_file="swift/src/quit_alert.swift"
    sha_file="${source_file}.sha256"
-   shasum -a 256 -- "${source_file}" > "${sha_file}"
+   /usr/bin/shasum --algorithm 256 -- "${source_file}" > "${sha_file}"
    echo "Updated ${sha_file}"
    ```
 
@@ -366,20 +393,46 @@ module Babble
 
       sig { returns(String) }
       def expected_hash
-        line = sha256_path.read.lines.first
-        T.must(line).split(/\s+/, 2).first.to_s.tap do |hex|
-          if hex.length != 64 || hex !~ /\A[0-9a-f]+\z/
-            odie <<~MSG
-              Babble's quit_alert.swift.sha256 file is malformed.
-              Path: #{sha256_path}
-              Run `brew update` to restore the canonical version.
-            MSG
-          end
+        unless sha256_path.exist?
+          odie <<~MSG
+            Babble's quit_alert.swift.sha256 file is missing.
+            Path: #{sha256_path}
+            Run `brew update` to restore the canonical version.
+          MSG
         end
+
+        line = sha256_path.read.lines.first
+        if line.nil? || line.strip.empty?
+          odie <<~MSG
+            Babble's quit_alert.swift.sha256 file is empty.
+            Path: #{sha256_path}
+            Run `brew update` to restore the canonical version.
+          MSG
+        end
+
+        hex = T.must(line).split(/\s+/, 2).first.to_s
+        unless hex.length == 64 && hex =~ /\A[0-9a-f]+\z/
+          odie <<~MSG
+            Babble's quit_alert.swift.sha256 file is malformed
+            (expected SHA256SUMS format with a 64-hex-char hash).
+            Path: #{sha256_path}
+            Run `brew update` to restore the canonical version.
+          MSG
+        end
+
+        hex
       end
 
       sig { returns(String) }
       def actual_hash
+        unless source_path.exist?
+          odie <<~MSG
+            Babble's quit_alert.swift source file is missing.
+            Path: #{source_path}
+            Run `brew update` to restore the tap.
+          MSG
+        end
+
         Digest::SHA256.file(source_path).hexdigest
       end
 
@@ -462,7 +515,7 @@ end
 The `ohai` messages above (under `compile!`) print to stderr
 on every first compile. The user sees:
 
-```
+```console
 ==> Compiling babble's quit_alert helper (one-time)
   Source: /opt/homebrew/Library/Taps/toobuntu/homebrew-babble/swift/src/quit_alert.swift
   Target: /Users/<user>/Library/Caches/Homebrew/babble/quit_alert_arm64_a1b2c3d4e5f6
@@ -499,7 +552,7 @@ compile + transparency message cycle.
 The cache filename includes a 12-hex-character prefix of
 the source hash:
 
-```
+```text
 ~/Library/Caches/Homebrew/babble/quit_alert_arm64_a1b2c3d4e5f6
 ```
 
@@ -524,12 +577,14 @@ Properties:
 - **Compile failure** (`xcrun swiftc` errors): caught by
   `compile!`'s `rescue ErrorDuringExecution`. Falls
   through to the osascript fallback per the main decision.
-- **`.sha256` file missing or malformed**: `odie` with
-  recovery instructions. Without a recorded hash, babble
-  can't verify, so it won't compile.
+- **`.sha256` file missing, empty, or malformed**: `odie`
+  with recovery instructions specific to each case.
+  `expected_hash` checks for each before attempting to
+  parse, so the documented messages fire instead of an
+  uncaught Ruby exception.
 - **Source file missing**: should never happen (the file
-  ships with the tap), but if so, the `Digest::SHA256.file`
-  call raises and propagates through to a clear error.
+  ships with the tap), but `actual_hash` checks explicitly
+  and `odie`s with recovery instructions if it does.
 
 ## Consequences
 

--- a/docs/migration-investigation/adrs/0001-swift-quit-alert-build-strategy.md
+++ b/docs/migration-investigation/adrs/0001-swift-quit-alert-build-strategy.md
@@ -182,6 +182,354 @@ W3 implementation:
 4. **No pre-built binaries** in the repo. The Swift source
    file (`swift/src/quit_alert.swift`) ships in the tap;
    the binary is always locally-built.
+5. **No `strip(1)`, no `-g` debug-info flag.** The default
+   `xcrun swiftc -O` output is already small (~50-100KB for
+   a single-NSAlert helper) with minimal debug info.
+   Stripping would save a few KB but adds a build step that
+   can fail in unexpected ways on Mach-O binaries; the size
+   savings don't justify the complexity for a tool of this
+   scope. Conversely, explicitly adding `-g` to bake in
+   debug info is unnecessary — the helper is stable and
+   single-purpose; if it ever misbehaves, the maintainer
+   can manually recompile with `-g` for that one debug
+   session.
+
+## Safety and transparency design
+
+Auto-compiling user-machine code from a source file the user
+did not write themselves is a real trust delegation. The
+design below makes the compile **safe** (verifiable; refuses
+to compile tampered sources) and **transparent** (visible to
+the user; no silent arbitrary code execution).
+
+### Source hash recorded in the repo
+
+A sibling file `swift/src/quit_alert.swift.sha256` is
+committed alongside the source. Standard SHA256SUMS format
+(`<sha256>  <path>`):
+
+```
+<64-hex-chars>  swift/src/quit_alert.swift
+```
+
+This format is verifiable from shell with one command:
+
+```sh
+cd <tap_dir>
+shasum -a 256 -c swift/src/quit_alert.swift.sha256
+```
+
+No Ruby required for the user to confirm the file matches
+what the maintainer committed. The .sha256 file is signed
+by the maintainer's GPG signature on the commit (per the
+org-wide signed-commits convention), so tampering with the
+.sha256 file requires breaking the signature too.
+
+### Maintenance flow
+
+The .sha256 file gets out of date if `quit_alert.swift`
+changes without a corresponding .sha256 update. Three
+layers of defense:
+
+1. **Pre-commit hook augmentation** at
+   `babble/.githooks/pre-commit.d/01-update-quit-alert-sha256.sh`.
+   The canonical pre-commit (synced from repo-foundation)
+   iterates `.githooks/pre-commit.d/*` in alphabetical order
+   and invokes each executable file in a subprocess — the
+   standard per-repo extension point, mirroring `/etc/cron.d`
+   and similar Unix drop-in conventions. babble's hook
+   regenerates the .sha256 sidecar from the staged content
+   of `quit_alert.swift`, runs `scripts/annotate.sh` to add
+   the .license sidecar, and stages both. Sketch:
+
+   ```bash
+   #!/usr/bin/env bash
+   # SPDX-FileCopyrightText: Copyright 2026 Todd Schulman
+   # SPDX-License-Identifier: GPL-3.0-or-later
+   #
+   # Pre-commit drop-in: regenerate quit_alert.swift's SHA256
+   # sidecar when the source is staged. Invoked by
+   # .githooks/pre-commit (canonical, synced from repo-foundation).
+
+   set -euo pipefail
+
+   main() {
+     cd "$(git rev-parse --show-toplevel)"
+     update_quit_alert_sha256
+   }
+
+   update_quit_alert_sha256() {
+     local source_file="swift/src/quit_alert.swift"
+     local sha_file="${source_file}.sha256"
+
+     # Only act when the source is staged in this commit.
+     if ! git diff --cached --name-only --diff-filter=ACM \
+          | /usr/bin/grep --quiet --line-regexp --fixed-strings -- "${source_file}"; then
+       return 0
+     fi
+
+     printf '==> Regenerating %s\n' "${sha_file}"
+
+     # Hash the staged content (not the working tree) so partial-
+     # staged commits produce a sidecar matching what's actually
+     # going into the commit.
+     local new_sha
+     new_sha=$(git show ":${source_file}" | shasum --algorithm 256 | awk '{print $1}')
+     printf '%s  %s\n' "${new_sha}" "${source_file}" > "${sha_file}"
+
+     # annotate.sh categorizes .sha256 files into the hash-files
+     # category (--force-dot-license), producing a .sha256.license
+     # sidecar without modifying the .sha256 file's content.
+     if [[ -x scripts/annotate.sh ]]; then
+       scripts/annotate.sh
+     fi
+
+     git add -- "${sha_file}"
+     if [[ -f "${sha_file}.license" ]]; then
+       git add -- "${sha_file}.license"
+     fi
+   }
+
+   main "$@"
+   ```
+
+   This hook runs only when `quit_alert.swift` is staged.
+   Other commits skip it entirely. The 2-digit `01-` prefix
+   establishes the ordering convention for any future
+   drop-ins; e.g. `02-some-other-check.sh`.
+
+2. **CI verification** at `.github/workflows/verify-sha256.yml`.
+   Runs on every PR and push:
+
+   ```yaml
+   - name: Verify quit_alert.swift hash
+     run: shasum -a 256 -c swift/src/quit_alert.swift.sha256
+   ```
+
+   This is the **enforcement layer**: a PR that modifies the
+   .swift file without a matching .sha256 fails CI and can't
+   merge. Catches drift even when the local pre-commit hook
+   wasn't installed (e.g., contributors who haven't run
+   `git config core.hooksPath .githooks`).
+
+3. **Standalone helper script** at
+   `scripts/update-quit-alert-sha256.sh`. Manual fallback
+   for situations where the pre-commit hook isn't running:
+   amending a commit that modified the source, fixing CI
+   failures during initial setup, etc.:
+
+   ```sh
+   #!/usr/bin/env bash
+   set -euo pipefail
+   source_file="swift/src/quit_alert.swift"
+   sha_file="${source_file}.sha256"
+   shasum -a 256 -- "${source_file}" > "${sha_file}"
+   echo "Updated ${sha_file}"
+   ```
+
+### Runtime verification in Ruby
+
+Before compile, babble computes the actual hash of
+`quit_alert.swift` and compares to the recorded value. On
+mismatch, **refuse to compile** with a clear error message:
+
+```ruby
+# typed: strict
+# frozen_string_literal: true
+
+require "digest"
+
+module Babble
+  module QuitAlertCompiler
+    extend T::Sig
+
+    class << self
+      sig { returns(Pathname) }
+      def ensure_binary
+        verify_source_hash!
+        cached_binary_path.tap do |binary|
+          compile!(binary) unless binary.exist?
+        end
+      end
+
+      private
+
+      sig { returns(Pathname) }
+      def source_path
+        tap_dir/"swift/src/quit_alert.swift"
+      end
+
+      sig { returns(Pathname) }
+      def sha256_path
+        Pathname("#{source_path}.sha256")
+      end
+
+      sig { returns(String) }
+      def expected_hash
+        line = sha256_path.read.lines.first
+        T.must(line).split(/\s+/, 2).first.to_s.tap do |hex|
+          if hex.length != 64 || hex !~ /\A[0-9a-f]+\z/
+            odie <<~MSG
+              Babble's quit_alert.swift.sha256 file is malformed.
+              Path: #{sha256_path}
+              Run `brew update` to restore the canonical version.
+            MSG
+          end
+        end
+      end
+
+      sig { returns(String) }
+      def actual_hash
+        Digest::SHA256.file(source_path).hexdigest
+      end
+
+      sig { void }
+      def verify_source_hash!
+        expected = expected_hash
+        actual = actual_hash
+        return if actual == expected
+
+        odie <<~MSG
+          Babble refused to compile quit_alert.swift: hash mismatch.
+
+          Expected: #{expected}
+          Actual:   #{actual}
+          Source:   #{source_path}
+
+          The Swift source file in the babble tap has been modified
+          outside the normal commit channel (the recorded hash in
+          quit_alert.swift.sha256 doesn't match). To restore the
+          canonical version:
+
+            brew update
+
+          If you have local modifications you intend to keep, update
+          the recorded hash via:
+
+            scripts/update-quit-alert-sha256.sh
+
+          Babble will not compile a source file whose hash doesn't
+          match the recorded value. This protects against accidental
+          corruption and unauthorized tampering of the tap.
+        MSG
+      end
+
+      sig { returns(Pathname) }
+      def cached_binary_path
+        cache_dir = HOMEBREW_CACHE/"babble"
+        arch = Hardware::CPU.arch.to_s
+        # Cache key includes a hash prefix so the binary auto-
+        # invalidates when the source changes (a new source hash
+        # produces a new cache filename; the old binary becomes
+        # orphaned and is collected by Homebrew's normal cache
+        # rotation).
+        cache_dir/"quit_alert_#{arch}_#{actual_hash[0, 12]}"
+      end
+
+      sig { params(binary_path: Pathname).void }
+      def compile!(binary_path)
+        binary_path.parent.mkpath
+
+        ohai "Compiling babble's quit_alert helper (one-time)"
+        puts "  Source: #{source_path}"
+        puts "  Target: #{binary_path}"
+        puts "  SHA256: #{actual_hash} (verified)"
+        puts "  Compile: xcrun swiftc -O -o <target> <source>"
+        puts
+        puts "  This compile happens once per source-hash change;"
+        puts "  subsequent runs use the cached binary."
+
+        safe_system "xcrun", "swiftc", "-O",
+                    "-o", binary_path.to_s,
+                    source_path.to_s
+      rescue ErrorDuringExecution
+        opoo "xcrun swiftc failed; will use osascript fallback for quit confirmations."
+        binary_path.unlink if binary_path.exist?
+        raise   # caller catches and switches to osascript path
+      end
+
+      sig { returns(Pathname) }
+      def tap_dir
+        Tap.fetch("toobuntu/babble").path
+      end
+    end
+  end
+end
+```
+
+### User-visible transparency on first compile
+
+The `ohai` messages above (under `compile!`) print to stderr
+on every first compile. The user sees:
+
+```
+==> Compiling babble's quit_alert helper (one-time)
+  Source: /opt/homebrew/Library/Taps/toobuntu/homebrew-babble/swift/src/quit_alert.swift
+  Target: /Users/<user>/Library/Caches/Homebrew/babble/quit_alert_arm64_a1b2c3d4e5f6
+  SHA256: a1b2c3d4...64-hex-chars (verified)
+  Compile: xcrun swiftc -O -o <target> <source>
+
+  This compile happens once per source-hash change;
+  subsequent runs use the cached binary.
+```
+
+The user can:
+
+- Open the source file at the printed path and read the
+  Swift source themselves before any compile completes (the
+  compile takes ~3-5 seconds; the user has time to Ctrl-C if
+  they want to inspect first)
+- Run `shasum -a 256 -c swift/src/quit_alert.swift.sha256`
+  manually to confirm the verification
+- See exactly what command produces the binary
+
+No silent arbitrary code execution.
+
+On subsequent runs (cache hit), no transparency messages
+are printed — the binary is treated as established
+infrastructure, like any other cached resource. Cache hit
+means the source hash matches what the binary was built
+from; the verification was performed and passed before the
+original compile. If the source changes, the cache key
+changes, the cache miss triggers a fresh verification +
+compile + transparency message cycle.
+
+### Cache key derivation
+
+The cache filename includes a 12-hex-character prefix of
+the source hash:
+
+```
+~/Library/Caches/Homebrew/babble/quit_alert_arm64_a1b2c3d4e5f6
+```
+
+Properties:
+
+- **Auto-invalidates** when the source changes: a new hash
+  produces a new filename; the binary built from the old
+  source becomes orphaned (Homebrew's cache rotation
+  eventually removes it)
+- **Architecture-specific**: separate cache entries for
+  arm64 vs x86_64
+- **Unambiguous**: the binary on disk corresponds to a
+  specific source-hash + arch combination; impossible to
+  accidentally use a binary built from a different source
+
+### Failure mode handling
+
+- **Source-hash mismatch** (verify failure): `odie` with
+  the error message above. Babble exits without compiling.
+  User must `brew update` (or update the .sha256 file
+  manually if they're modifying the source intentionally).
+- **Compile failure** (`xcrun swiftc` errors): caught by
+  `compile!`'s `rescue ErrorDuringExecution`. Falls
+  through to the osascript fallback per the main decision.
+- **`.sha256` file missing or malformed**: `odie` with
+  recovery instructions. Without a recorded hash, babble
+  can't verify, so it won't compile.
+- **Source file missing**: should never happen (the file
+  ships with the tap), but if so, the `Digest::SHA256.file`
+  call raises and propagates through to a clear error.
 
 ## Consequences
 
@@ -195,6 +543,18 @@ W3 implementation:
 - Graceful degradation if Swift compilation isn't possible
 - Easy to update the Swift source without re-releasing
   binaries
+- **Compile-time verification**: source hash is checked
+  against a committed sidecar before any compile, refusing
+  to build tampered sources
+- **CI enforcement**: a PR that modifies the .swift file
+  without updating the .sha256 sidecar fails CI; drift is
+  caught upstream of any user
+- **Transparency**: first compile prints source path,
+  target path, command, and verified hash; user can
+  inspect or interrupt before the compile completes
+- **Cache auto-invalidation**: cache key includes the
+  source hash, so a source change forces a fresh
+  verification + compile cycle
 
 **Bad:**
 - First run is slower than no-build cases
@@ -204,6 +564,9 @@ W3 implementation:
   install-time errors (mitigation: graceful osascript
   fallback)
 - Cache management complexity (small; hash-based)
+- **One additional file to keep in sync** (the .sha256
+  sidecar). Mitigation: helper script in `scripts/`,
+  optional pre-commit augmentation, mandatory CI check.
 
 **Tradeoff acknowledged:** users without
 xcode-command-line-tools fall through to the osascript
@@ -230,3 +593,16 @@ constraint of no-cert distribution.
 - Compilation latency becomes user-visible problematic
   (e.g., multiple compiles per session due to cache
   invalidation issues)
+- **Homebrew bottle distribution becomes verified-viable for
+  Swift binaries that show NSAlert.** Homebrew bottles are
+  built on GitHub Actions runners and ad-hoc signed
+  (no Apple Developer cert needed); the install process
+  strips the `com.apple.quarantine` xattr. CLI binaries work
+  fine via this path. Whether ad-hoc-signed-via-CI Swift
+  binaries that call `NSApp`/NSAlert APIs work reliably on
+  current macOS (especially macOS 14+ Sonoma's tightened
+  Gatekeeper) is open without empirical testing. If a future
+  test confirms it works, switching to bottle distribution
+  removes the first-run compile latency and the
+  xcode-command-line-tools requirement. Until then, the
+  auto-compile path is the safe choice.


### PR DESCRIPTION
Adds class-vs-module decomposition pattern; refines babble.env to two-tier (user/system) with BABBLE_SYSTEM_ENV_TAKES_PRIORITY; strengthens Sorbet typing and adds Testing discipline sections; documents upstream bootsnap fix history; adds Safety and transparency design to ADR 0001 (SHA256 sidecar via .githooks/pre-commit.d/ drop-in, CI enforcement, runtime verification, ohai transparency, cache auto-invalidation, no strip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture guidance with class-vs-module decomposition and component classification rules
  * Reworked environment/config precedence and added a sysadmin override behavior for env sources
  * Added concrete examples for entry-point, phase, and utility patterns and stricter testing/Sorbet discipline
  * Enhanced Swift quit-alert build strategy with SHA256-sidecar verification, compile/cache transparency, and failure handling notes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toobuntu/babble/pull/5)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->