### PR TITLE
"docs: fix paths after toobuntu/ reorg; annotate Go style fix"

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -88,7 +88,7 @@ instructions in `_claude-config-baseline/README.md` § "Initial setup
 
 Each Claude Code session in this plan runs at one of the four
 isolation tiers defined in
-`~/devel/claude/desktop/blackoutd/docs/decisions/0007-layered-isolation-strategy.md`.
+`~/devel/claude/desktop/toobuntu/blackoutd/docs/decisions/0007-layered-isolation-strategy.md`.
 Read the ADR if you haven't recently. Short summary:
 
 - **Tier 1** — Primary checkout, in-host Seatbelt + permission rules.
@@ -122,7 +122,7 @@ PR. Tier 4 doesn't appear because babble doesn't use Mach IPC and
 the work isn't adversarial-capability-tier.
 
 The `sandbox-enter.sh` script lives in
-`~/devel/claude/desktop/blackoutd/scripts/sandbox-enter.sh` (it
+`~/devel/claude/desktop/toobuntu/blackoutd/scripts/sandbox-enter.sh` (it
 hasn't been promoted to `scaffolding/scripts/` yet). Copy it into
 `babble-ruby/scripts/` during Block 0 so it's in place when Block B
 starts.
@@ -140,7 +140,7 @@ Before anything else, confirm the planning artifacts are in place
 and the prompt-text scrub worked:
 
 ```sh
-cd ~/devel/claude/desktop/babble
+cd ~/devel/claude/desktop/toobuntu/babble
 ls -la docs/                   # README.md, handoff.md, tech-debt.md (or technical-debt.md), decisions/, reviews/
 ls -la docs/reviews/           # pr1-review.md, pr3-review.md
 ls -la archive/                # _OPENING_PROMPT.txt, _usr_local_bin_bbl, babble/
@@ -159,7 +159,7 @@ currently ships as `docs/tech-debt.md`; rename now while it's still
 unreferenced by external links:
 
 ```sh
-cd ~/devel/claude/desktop/babble
+cd ~/devel/claude/desktop/toobuntu/babble
 git mv docs/tech-debt.md docs/technical-debt.md
 
 # Update the cross-references in handoff.md and README.md
@@ -195,7 +195,7 @@ also the audit trail for why the Ruby migration looks the way it
 does, and they belong with the code. Commit them on `main`.
 
 ```sh
-cd ~/devel/claude/desktop/babble
+cd ~/devel/claude/desktop/toobuntu/babble
 
 # Clean up the working copies of this file
 rm docs/handoff.md.0 docs/handoff.md.1
@@ -289,7 +289,7 @@ the disk per our earlier discussion.
 
 ```sh
 # Tear down the planning-session worktrees
-cd ~/devel/claude/desktop/babble
+cd ~/devel/claude/desktop/toobuntu/babble
 git worktree list               # confirm the 4 worktrees
 git worktree remove ../babble-pr1
 git worktree remove ../babble-pr3
@@ -307,7 +307,7 @@ git switch -c ruby-migration
 git push -u origin ruby-migration
 ```
 
-The original `~/devel/claude/desktop/babble/` clone now serves as
+The original `~/devel/claude/desktop/toobuntu/babble/` clone now serves as
 the "main / released versions" reference. The new
 `~/devel/claude/desktop/babble-ruby/` clone is where Ruby migration
 work happens. Two physical clones, two mental boxes.
@@ -399,7 +399,7 @@ git switch ruby-migration
 
 # Source paths — adjust if/when scaffolding/project/ gets populated
 B=~/devel/claude/desktop/_claude-config-baseline
-BD=~/devel/claude/desktop/blackoutd
+BD=~/devel/claude/desktop/toobuntu/blackoutd
 
 # Per-repo Claude Code config
 mkdir -p .claude scripts
@@ -902,8 +902,8 @@ Copy-paste the following into Claude Code:
 > `CLAUDE.md`, `docs/agent-principles.md`, `.claude/settings.json`,
 > sandbox scripts). I am running this session at Tier 3
 > (fresh-clone-no-remote). The reference repos to model on are
-> `~/devel/claude/desktop/homebrew-cask-tools/` and
-> `~/devel/claude/desktop/blackoutd/`.
+> `~/devel/claude/desktop/toobuntu/homebrew-cask-tools/` and
+> `~/devel/claude/desktop/toobuntu/blackoutd/`.
 >
 > Read these documents first, in order:
 >
@@ -919,13 +919,13 @@ Copy-paste the following into Claude Code:
 >    Ruby-toolchain part)
 > 5. `docs/reviews/pr1-review.md` (the rationale for why this
 >    branch exists)
-> 6. `~/devel/claude/desktop/homebrew-cask-tools/.github/workflows/ci.yml`
+> 6. `~/devel/claude/desktop/toobuntu/homebrew-cask-tools/.github/workflows/ci.yml`
 >    (the canonical model for `brew style` + `brew install-bundler-gems`
 >    in CI)
-> 7. `~/devel/claude/desktop/homebrew-cask-tools/cmd/purge-quarantine.rb`
+> 7. `~/devel/claude/desktop/toobuntu/homebrew-cask-tools/cmd/purge-quarantine.rb`
 >    (the canonical model for Sorbet sigs and `T.let`/`T.unsafe`
 >    patterns)
-> 8. `~/devel/claude/desktop/blackoutd/Gemfile` (template for a
+> 8. `~/devel/claude/desktop/toobuntu/blackoutd/Gemfile` (template for a
 >    minimal Gemfile)
 >
 > Decisions already locked (do not re-litigate):
@@ -1242,7 +1242,7 @@ Copy-paste the following into Claude Code:
 >    do NOT copy code wholesale; the entire reason we're rewriting
 >    is that those files have bugs. Use as architectural reference
 >    only.
-> 5. `~/devel/claude/desktop/babble/archive/babble/ruby/refactor/ruby/lib/utils/running_gui_bundle_ids.rb`
+> 5. `~/devel/claude/desktop/toobuntu/babble/archive/babble/ruby/refactor/ruby/lib/utils/running_gui_bundle_ids.rb`
 >    — the prototype's working `bundleID` parser
 >
 > **Scope of this session:**
@@ -1284,7 +1284,7 @@ Copy-paste the following into Claude Code:
 > **Sorbet sigs**: every public method gets a `sig`.
 > `T::Sig::WithoutRuntime` is fine for performance-sensitive paths
 > (none in this batch). Reference the `sig`/`T.let`/`T.unsafe`
-> patterns in `~/devel/claude/desktop/homebrew-cask-tools/cmd/purge-quarantine.rb`.
+> patterns in `~/devel/claude/desktop/toobuntu/homebrew-cask-tools/cmd/purge-quarantine.rb`.
 >
 > **Conventions** (per `docs/agent-principles.md`):
 > - Module namespace `Babble::*`

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -296,11 +296,11 @@ git worktree remove ../babble-pr3
 git worktree remove ../babble-refactor-modular
 git worktree remove ../babble-base64
 git worktree prune              # clean up administrative entries
-ls ../                          # confirm only `babble` remains under desktop/
+ls ../                          # confirm the babble-* worktrees are gone
 
 # Make a fresh full clone for the Ruby migration work.
-# This goes in ~/devel/claude/desktop/ so Filesystem MCP can reach it.
-cd ~/devel/claude/desktop
+# This goes in ~/devel/claude/desktop/toobuntu/ so Filesystem MCP can reach it.
+cd ~/devel/claude/desktop/toobuntu
 git clone https://github.com/toobuntu/babble.git babble-ruby
 cd babble-ruby
 git switch -c ruby-migration
@@ -309,7 +309,7 @@ git push -u origin ruby-migration
 
 The original `~/devel/claude/desktop/toobuntu/babble/` clone now serves as
 the "main / released versions" reference. The new
-`~/devel/claude/desktop/babble-ruby/` clone is where Ruby migration
+`~/devel/claude/desktop/toobuntu/babble-ruby/` clone is where Ruby migration
 work happens. Two physical clones, two mental boxes.
 
 ### A.7 — Add the GitHub branch protection ruleset
@@ -390,11 +390,11 @@ items at the end of this file).
 
 ### 0.1 — Copy the templates
 
-Working in `~/devel/claude/desktop/babble-ruby/` on the
+Working in `~/devel/claude/desktop/toobuntu/babble-ruby/` on the
 `ruby-migration` branch:
 
 ```sh
-cd ~/devel/claude/desktop/babble-ruby
+cd ~/devel/claude/desktop/toobuntu/babble-ruby
 git switch ruby-migration
 
 # Source paths — adjust if/when scaffolding/project/ gets populated
@@ -875,7 +875,7 @@ many times (every `git commit`, every `gh` invocation). Per ADR
 0007's escalation triggers, run at Tier 3:
 
 ```sh
-cd ~/devel/claude/desktop/babble-ruby
+cd ~/devel/claude/desktop/toobuntu/babble-ruby
 ./scripts/sandbox-enter.sh --mode=no-remote
 # This creates a fresh clone with no remote configured. The script
 # prints the sandbox path and may launch a sub-shell or print a
@@ -1114,7 +1114,7 @@ Copy-paste the following into Claude Code:
 >    this sandbox clone). The procedure is roughly:
 >
 >    ```sh
->    # In the primary checkout (~/devel/claude/desktop/babble-ruby):
+>    # In the primary checkout (~/devel/claude/desktop/toobuntu/babble-ruby):
 >    git fetch <sandbox-path>/.git b1-ruby-toolchain:b1-ruby-toolchain
 >    git switch b1-ruby-toolchain
 >    git push origin b1-ruby-toolchain
@@ -1135,7 +1135,7 @@ After Claude Code reports back:
    the sandbox dir so you can fetch from it.
 2. From the primary checkout, fetch the branch from the sandbox:
    ```sh
-   cd ~/devel/claude/desktop/babble-ruby
+   cd ~/devel/claude/desktop/toobuntu/babble-ruby
    git fetch /tmp/babble-ruby-sandbox b1-ruby-toolchain:b1-ruby-toolchain
    # Adjust path to whatever sandbox-enter.sh used
    ```
@@ -1216,7 +1216,7 @@ next prompt informed by what actually shipped.
 Same Tier 3 entry pattern as Block B:
 
 ```sh
-cd ~/devel/claude/desktop/babble-ruby
+cd ~/devel/claude/desktop/toobuntu/babble-ruby
 ./scripts/sandbox-enter.sh --mode=no-remote
 # Then launch Claude Code from inside the sandbox clone.
 ```

--- a/docs/preservation-actions.md
+++ b/docs/preservation-actions.md
@@ -41,7 +41,7 @@ intermediate Ruby release.
 Verify the babble repo state before launching:
 
 ```sh
-cd ~/devel/claude/desktop/babble
+cd ~/devel/claude/desktop/toobuntu/babble
 git status                       # clean on main
 git fetch --all --prune
 git branch --all --sort=-committerdate
@@ -67,9 +67,9 @@ session reads these to populate
 present:
 
 ```sh
-ls -la ~/devel/claude/desktop/babble/archive/babble/ruby/refactor/ruby/lib/
-ls -la ~/devel/claude/desktop/babble/archive/babble/ruby/refactor/ruby/lib/utils/
-ls -la ~/devel/claude/desktop/babble/archive/babble/ruby/refactor/ruby/lib/macos_interface/
+ls -la ~/devel/claude/desktop/toobuntu/babble/archive/babble/ruby/refactor/ruby/lib/
+ls -la ~/devel/claude/desktop/toobuntu/babble/archive/babble/ruby/refactor/ruby/lib/utils/
+ls -la ~/devel/claude/desktop/toobuntu/babble/archive/babble/ruby/refactor/ruby/lib/macos_interface/
 ```
 
 Expected files include `brew_cask_utils.rb`, `brew_update.rb`,
@@ -87,11 +87,11 @@ W2 needs `scripts/sandbox-enter.sh` (to enter Tier 3) and
 either. Copy from blackoutd before launching:
 
 ```sh
-cd ~/devel/claude/desktop/babble
+cd ~/devel/claude/desktop/toobuntu/babble
 mkdir -p scripts
-cp ~/devel/claude/desktop/blackoutd/scripts/sandbox-enter.sh scripts/
-cp ~/devel/claude/desktop/blackoutd/scripts/sandbox-exit.sh scripts/
-cp ~/devel/claude/desktop/blackoutd/scripts/annotate.sh scripts/
+cp ~/devel/claude/desktop/toobuntu/blackoutd/scripts/sandbox-enter.sh scripts/
+cp ~/devel/claude/desktop/toobuntu/blackoutd/scripts/sandbox-exit.sh scripts/
+cp ~/devel/claude/desktop/toobuntu/blackoutd/scripts/annotate.sh scripts/
 chmod +x scripts/*.sh
 ```
 
@@ -101,16 +101,16 @@ blackoutd scripts work fine.
 
 ## Claude Code session: triage + preservation
 
-Run at Tier 3 from `~/devel/claude/desktop/babble/`:
+Run at Tier 3 from `~/devel/claude/desktop/toobuntu/babble/`:
 
 ```sh
-cd ~/devel/claude/desktop/babble
+cd ~/devel/claude/desktop/toobuntu/babble
 ./scripts/sandbox-enter.sh --mode=no-remote
 # Enter the sandbox dir; launch Claude Code from there.
 ```
 
 The Claude Code prompt is at
-`~/devel/claude/desktop/babble/docs/preservation-prompt.md`. Copy
+`~/devel/claude/desktop/toobuntu/babble/docs/preservation-prompt.md`. Copy
 the prompt body (between `>>>` markers) and paste.
 
 When Claude Code reports back, it will provide:
@@ -131,14 +131,14 @@ After approving the triage:
 1. Exit the sandbox.
 2. Fetch the branch from the sandbox:
    ```sh
-   cd ~/devel/claude/desktop/babble
+   cd ~/devel/claude/desktop/toobuntu/babble
    git fetch /tmp/babble-sandbox/.git \
      preservation-archive:preservation-archive
    git switch preservation-archive
    ```
 3. Review the new `docs/migration-investigation/` directory:
    ```sh
-   tree ~/devel/claude/desktop/babble/docs/migration-investigation/
+   tree ~/devel/claude/desktop/toobuntu/babble/docs/migration-investigation/
    ```
 4. Read `00-meta-overview.md` and `01-decisions.md` carefully —
    these are the high-traffic entry points.

--- a/docs/preservation-actions.md
+++ b/docs/preservation-actions.md
@@ -130,16 +130,20 @@ After approving the triage:
 
 1. Exit the sandbox.
 2. Fetch the branch from the sandbox:
+
    ```sh
    cd ~/devel/claude/desktop/toobuntu/babble
    git fetch /tmp/babble-sandbox/.git \
      preservation-archive:preservation-archive
    git switch preservation-archive
    ```
+
 3. Review the new `docs/migration-investigation/` directory:
+
    ```sh
    tree ~/devel/claude/desktop/toobuntu/babble/docs/migration-investigation/
    ```
+
 4. Read `00-meta-overview.md` and `01-decisions.md` carefully —
    these are the high-traffic entry points.
 5. Spot-check 2-3 of the `modules/*.md` files.
@@ -149,6 +153,7 @@ After approving the triage:
    (e.g., cherry-picks from a dead branch), review and apply
    those manually before pushing the preservation branch.
 8. Push and merge:
+
    ```sh
    git push origin preservation-archive
    gh pr create --base main \

--- a/docs/preservation-prompt.md
+++ b/docs/preservation-prompt.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 Copy everything between the `>>>` markers into Claude Code. This
 runs at Tier 3 (fresh-clone-no-remote sandbox), launched from
-inside `~/devel/claude/desktop/babble/` after running
+inside `~/devel/claude/desktop/toobuntu/babble/` after running
 `./scripts/sandbox-enter.sh --mode=no-remote`.
 
 >>>
@@ -496,7 +496,7 @@ When done:
 - Don't modify `bbl` (the ksh script).
 - Don't touch any of the user's other repos
   (blackoutd, homebrew-cask-tools, brew, etc.) beyond reading
-  `~/devel/claude/desktop/blackoutd/scripts/` for the
+  `~/devel/claude/desktop/toobuntu/blackoutd/scripts/` for the
   annotate.sh and sandbox-enter.sh sources if they aren't
   already in babble's scripts/.
 - Don't touch `docs/handoff.md` or `docs/technical-debt.md`

--- a/scripts/annotate.sh
+++ b/scripts/annotate.sh
@@ -10,7 +10,7 @@
 # working set before the next is matched, so ORDER MATTERS):
 #
 #   1. C / Objective-C source (.m/.h/.c)               → --style=c     (// comments)
-#   2. Go source (.go)                                  → --style=go    (// comments)
+#   2. Go source (.go)                                  → --style=c    (// comments)
 #   3. Generated completion files (completions/**)      → sidecar       (--force-dot-license)
 #   4. Man pages (.[1-9], .[1-9][a-z]*, with optional   → sidecar       (--force-dot-license)
 #      .md suffix; e.g. progname.1, progname.3p,
@@ -133,7 +133,7 @@ remaining=$(printf '%s\n' "${remaining}" | grep --invert-match --extended-regexp
 other_files=$(printf '%s\n' "${remaining}" || true)
 
 [[ -n ${c_files} ]]      && printf '%s\n' "${c_files}"      | annotate --style=c
-[[ -n ${go_files} ]]     && printf '%s\n' "${go_files}"     | annotate --style=go
+[[ -n ${go_files} ]]     && printf '%s\n' "${go_files}"     | annotate --style=c
 [[ -n ${compl_files} ]]  && printf '%s\n' "${compl_files}"  | annotate --force-dot-license
 [[ -n ${man_files} ]]    && printf '%s\n' "${man_files}"    | annotate --force-dot-license
 [[ -n ${markup_files} ]] && printf '%s\n' "${markup_files}" | annotate --style=html

--- a/stash/code-archive/README.md
+++ b/stash/code-archive/README.md
@@ -38,9 +38,9 @@ The maintainer's existing worktrees:
 
 ```sh
 git worktree list
-# /Users/todd/devel/claude/desktop/babble                  [main]
+# /Users/todd/devel/claude/desktop/toobuntu/babble                  [main]
 # /Users/todd/devel/claude/desktop/babble-base64           [base64]
-# /Users/todd/devel/claude/desktop/babble-refactor-modular [refactor/modular]
+# /Users/todd/devel/claude/desktop/toobuntu/babble-refactor-modular [refactor/modular]
 ```
 
 (The PR-1 and PR-3 worktrees can be torn down before this
@@ -49,11 +49,11 @@ since those branches are being discarded.)
 
 ### Extract from refactor/modular
 
-Run from `~/devel/claude/desktop/babble-refactor-modular`:
+Run from `~/devel/claude/desktop/toobuntu/babble-refactor-modular`:
 
 ```sh
-cd ~/devel/claude/desktop/babble-refactor-modular
-DEST=~/devel/claude/desktop/babble/docs/migration-investigation/code-archive/refactor-modular
+cd ~/devel/claude/desktop/toobuntu/babble-refactor-modular
+DEST=~/devel/claude/desktop/toobuntu/babble/docs/migration-investigation/code-archive/refactor-modular
 
 # Mirror the relevant tree under refactor/ into the archive.
 # Use rsync to preserve permissions and skip .git stuff.
@@ -110,7 +110,7 @@ Run from `~/devel/claude/desktop/babble-base64`:
 
 ```sh
 cd ~/devel/claude/desktop/babble-base64
-DEST=~/devel/claude/desktop/babble/docs/migration-investigation/code-archive/base64
+DEST=~/devel/claude/desktop/toobuntu/babble/docs/migration-investigation/code-archive/base64
 
 mkdir -p "$DEST"
 
@@ -136,7 +136,7 @@ Run from `~/devel/claude/desktop/babble-pr1`:
 
 ```sh
 cd ~/devel/claude/desktop/babble-pr1
-DEST=~/devel/claude/desktop/babble/docs/migration-investigation/code-archive/pr1
+DEST=~/devel/claude/desktop/toobuntu/babble/docs/migration-investigation/code-archive/pr1
 
 mkdir -p "$DEST"
 
@@ -167,7 +167,7 @@ After extraction, run the annotate script (assuming it's
 been copied in as part of W2 setup):
 
 ```sh
-cd ~/devel/claude/desktop/babble
+cd ~/devel/claude/desktop/toobuntu/babble
 bash scripts/annotate.sh
 
 # Verify reuse compliance

--- a/stash/code-archive/README.md
+++ b/stash/code-archive/README.md
@@ -11,6 +11,14 @@ from the archived branches. Each subdirectory corresponds to
 one source. Files preserve their original SPDX headers if
 present.
 
+> **Status — completed.** This extraction ran during the v0.5
+> preservation work; the `code-archive/` below is populated. The
+> `babble-base64` and `babble-pr1` worktrees it references were torn
+> down afterward (base64 archived as the `archive/2026-05-07-ksh-base64`
+> tag; PR-1 discarded). Their `~/devel/claude/desktop/babble-*` paths
+> predate the `toobuntu/` reorg and are kept as a historical record,
+> not live instructions.
+
 ## Subdirectories
 
 - `refactor-modular/` — extracts from


### PR DESCRIPTION
## Summary

Two changes surfaced by the `toobuntu/` reorg pass:

- **`fix(scripts)`** — `annotate.sh` invoked `reuse annotate --style=go`, which is not a valid reuse comment style. Go uses `//` line comments identical to C, so this switches Go sources to `--style=c` (the dispatch line and the documenting comment table). Interim fix; `scripts/annotate.sh` will later be synced from repo-foundation.
- **`docs`** — update stale absolute paths in the handoff/preservation docs after the desktop repos moved under a shared `toobuntu/` parent (`~/devel/claude/desktop/<repo>` → `.../desktop/toobuntu/<repo>`), covering references to babble, blackoutd, and homebrew-cask-tools.

## Files

`scripts/annotate.sh`, `docs/handoff.md`, `docs/preservation-actions.md`, `docs/preservation-prompt.md`, `stash/code-archive/README.md`

Docs-and-tooling only; no change to shipped code behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated handoff guides, preservation action steps, and prompt documentation with revised local filesystem paths and references to reflect workspace structure changes.

* **Chores**
  * Updated maintainer instructions and scripts to align with new workspace paths.
  * Adjusted Go source code annotation formatting in build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->